### PR TITLE
Fix list of dependencies

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="C0 Package for 15-122"
 url="http://c0.typesafety.net/index.html"
 arch=('x86_64' 'i686')
 license=('GPL')
-depends=('libpng12>=1.2','zlib>=1.2','make>=4.0', 'gcc>=5.1','ncurses5-compat-libs>=6.0')
+depends=('libpng12>=1.2' 'zlib>=1.2' 'make>=4.0' 'gcc>=5.1' 'ncurses5-compat-libs>=6.0')
 provides=('coin','cc0')
 source=("$pkgname::http://c0.typesafety.net/dist/cc0-v0523-linux3.13.0-64bit-bin.tgz")
 md5sums=('c58f4b8720785ccc4063d2f5f3209da0')


### PR DESCRIPTION
Bash doesn't use commas in arrays
