### PR TITLE
Update for r771

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,21 +1,27 @@
 # Maintainer: Derek Brown <derekbro@andrew.cmu.edu>
 pkgname=c0
-pkgver=0.718
+pkgver=0.771
 pkgrel=1
 pkgdesc="C0 Package for 15-122"
-url="http://c0.typesafety.net/index.html"
+url="http://c0.cs.cmu.edu"
 arch=('x86_64' 'i686')
-license=('GPL')
-depends=('libpng12>=1.2' 'zlib>=1.2' 'make>=4.0' 'gcc>=5.1' 'ncurses5-compat-libs>=6.0')
+license=('MIT')
+depends=('libpng>=1.2' 'zlib>=1.2' 'make>=4.0' 'gcc>=5.1' 'ncurses5-compat-libs>=6.0')
 provides=('coin' 'cc0')
-source=("$pkgname::http://c0.typesafety.net/dist/cc0-v718-ubuntu18.04.5-bin.tgz")
-md5sums=('14fdd3331bbe42831cfb8725bd258170')
+source=("$pkgname::https://c0.cs.cmu.edu/downloads/aux/cc0-r771.tgz" "fno-common.patch")
+md5sums=('e03e3c90b07603d899acedfc445faaf4'
+         '41a1d89191c6420779cf05a1f55339ab')
+
+prepare() {
+    cd "cc0.r771"
+    patch --forward --strip=1 --input="${srcdir}/fno-common.patch"
+}
 
 package() {
 
   # Create Installation Folder Structure
   mkdir -p $pkgdir/usr/lib/c0
-  cp -r $srcdir/cc0-v718-ubuntu18.04.5-bin/* $pkgdir/usr/lib/c0
+  cp -r $srcdir/cc0.r771/* $pkgdir/usr/lib/c0
 
   mkdir -p $pkgdir/usr/bin
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Derek Brown <derekbro@andrew.cmu.edu>
 pkgname=c0
-pkgver=0.590
+pkgver=0.718
 pkgrel=1
 pkgdesc="C0 Package for 15-122"
 url="http://c0.typesafety.net/index.html"
@@ -8,14 +8,14 @@ arch=('x86_64' 'i686')
 license=('GPL')
 depends=('libpng12>=1.2' 'zlib>=1.2' 'make>=4.0' 'gcc>=5.1' 'ncurses5-compat-libs>=6.0')
 provides=('coin' 'cc0')
-source=("$pkgname::http://c0.typesafety.net/dist/cc0-v0590-linux4.4.0-bin.tgz")
-md5sums=('62e51ffbb7f6b03c7e863757c9705922')
+source=("$pkgname::http://c0.typesafety.net/dist/cc0-v718-ubuntu18.04.5-bin.tgz")
+md5sums=('14fdd3331bbe42831cfb8725bd258170')
 
 package() {
 
   # Create Installation Folder Structure
   mkdir -p $pkgdir/usr/lib/c0
-  cp -r $srcdir/cc0/* $pkgdir/usr/lib/c0
+  cp -r $srcdir/cc0-v718-ubuntu18.04.5-bin/* $pkgdir/usr/lib/c0
 
   mkdir -p $pkgdir/usr/bin
 

--- a/fno-common.patch
+++ b/fno-common.patch
@@ -1,0 +1,14 @@
+diff '--color=auto' --unified --recursive --text cc0.r771/lib/cc0main.c cc0.r771.new/lib/cc0main.c
+--- cc0.r771/lib/cc0main.c	2021-01-12 12:20:49.000000000 -0500
++++ cc0.r771.new/lib/cc0main.c	2021-07-01 19:56:59.398515215 -0400
+@@ -16,8 +16,8 @@
+ char **c0_argv;
+ 
+ // Defined externally by CC0
+-long map_length;
+-const char* source_map[0];
++extern long map_length;
++extern const char* source_map[0];
+ 
+ FILE *really_fopen(const char *filename, const char *mode,
+                    char *error)


### PR DESCRIPTION
- Changes download link to point to migrated sources.

- Change listed licence from GPL to MIT. While the licence will likely change
  (at least for some code, namely coin) with the inclusion of readline in
  coin in the future, the current correct licence according to the
  project maintainers is MIT.

- Adds a minor patch for `lib/cc0main.c` which changes the linkage
  specification to be correct. This was previously not an issue due to
  gcc's (<10) handling of common symbols. As fno-common is now default
  in gcc 10+, the unpatched source causes linkage errors when compiling
  c0 code.

This package should probably be renamed to `c0-bin` or similar, given that sources are available.

I'm also willing to take over maintainership of this package.